### PR TITLE
KMA-6 - Generate an 'id' for the github branch source element

### DIFF
--- a/jenkins_jobs/modules/branch_sources.py
+++ b/jenkins_jobs/modules/branch_sources.py
@@ -69,6 +69,10 @@ def github(registry, xml_parent, data):
         for behavior, behavior_data in behaviors.items():
             add_behavior(behavior, behavior_data, traits)
 
+    # We are responsible for setting an id
+    # See https://issues.jenkins-ci.org/browse/JENKINS-48571
+    XML.SubElement(xml_parent, 'id').text = str(hash(XML.tostring(xml_parent)))
+
 
 def add_behavior(behavior, behavior_data, traits):
     behavior_data = {} if behavior_data is None else behavior_data

--- a/tests/properties/fixtures/pipeline-libraries.xml
+++ b/tests/properties/fixtures/pipeline-libraries.xml
@@ -21,6 +21,7 @@
                   <strategyId>3</strategyId>
                 </org.jenkinsci.plugins.github__branch__source.OriginPullRequestDiscoveryTrait>
               </traits>
+              <id>-1893506622473322320</id>
             </scm>
           </retriever>
         </org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>

--- a/tests/yamlparser/fixtures/project_multibranch_pipeline_template001.xml
+++ b/tests/yamlparser/fixtures/project_multibranch_pipeline_template001.xml
@@ -38,6 +38,7 @@
               <excludes/>
             </jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait>
           </traits>
+          <id>-6880172972930136773</id>
         </source>
         <strategy class="jenkins.branch.DefaultBranchPropertyStrategy">
           <properties class="java.util.Arrays$ArrayList">

--- a/tests/yamlparser/fixtures/project_multibranch_pipeline_template002.xml
+++ b/tests/yamlparser/fixtures/project_multibranch_pipeline_template002.xml
@@ -33,6 +33,7 @@
               <trust class="org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustContributors"/>
             </org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait>
           </traits>
+          <id>-2226602702690708545</id>
         </source>
         <strategy class="jenkins.branch.DefaultBranchPropertyStrategy">
           <properties class="empty-list"/>


### PR DESCRIPTION
Jenkins used to handle this fine, even though it apparently violated the contract
(based on some of Stephen Conolly's [comments in this jira](https://issues.jenkins-ci.org/browse/JENKINS-46290?focusedCommentId=329124&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-329124), and [this one](https://issues.jenkins-ci.org/browse/JENKINS-48571)).
Jenkins doesn't handle this anymore, with a
"Could not determine exact tip revision of ..." error message.

In some cases the id is supposed to reflect any config options,
but I am not sure our use case is one of those.
I'm assuming it is, so the id we'll generate here should be stable but should change
if any of the traits change.



I ran into this error recently when we rebuilt jenkins-lab for CruGlobal/cru-ansible#279

Supports work towards https://jira.cru.org/browse/KMA-6.